### PR TITLE
add syntax highlight for elements with a single dash

### DIFF
--- a/syntaxes/bemSupport.tmLanguage.json
+++ b/syntaxes/bemSupport.tmLanguage.json
@@ -20,6 +20,14 @@
             "1": { "name": "entity.name.tag.reference.scss" },
             "2": { "name": "bem.support.modifier.scss" }
           }
+        },
+        {
+          "match": "(&)(_[-a-zA-Z_0-9]*)",
+          "name": "entity.other.attribute-name.class.css",
+          "captures": {
+            "1": { "name": "entity.name.tag.reference.scss" },
+            "2": { "name": "bem.support.element.scss" }
+          }
         }
       ]
 		}


### PR DESCRIPTION
I really like your plugin! I've been learning SASS on my own, and I'm glad I found your plugin as I couldn't find any alternatives. However, I noticed a minor issue with syntax highlighting.

For example, the following syntax is correctly highlighted: .block__element
e.g.:

.header
.header__logo
It works well. However, when I use SASS, your plugin ignores other BEM syntax. We were also taught BEM syntax like:
.class_modifier and .class_key_value (Single underscores are intentionally used)

For instance:

.header {
&_small { }
&_color_cyan { }
&_color_red { }
}
Unfortunately, your plugin doesn't highlight thisyntax. Could you please add syntax highlighting for these as well?